### PR TITLE
utf-8 encoding - fix Windows install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ elif sys.version_info < (3,0):
 
 
 def read(fname):
-    return open(os.path.join(os.path.dirname(__file__), fname)).read()
+    return open(os.path.join(os.path.dirname(__file__), fname), encoding='utf-8').read()
 
 setup(
 	name = "ymap",


### PR DESCRIPTION
Think we should also try to understand why this fix works. All I know (is memory serves correctly) is that it solved the UnicodeDecodeError that we obtained when trying to install with 'pip install ymap'.

Also just checking whether this pull request works :)